### PR TITLE
Require Cabal 1.8+

### DIFF
--- a/brainfuck.cabal
+++ b/brainfuck.cabal
@@ -12,7 +12,7 @@ description:         This is an interpreter of the brainf*ck language,
                      written in the pure, lazy, functional language Haskell.
 
 build-type:          Simple
-cabal-version:       >= 1.6
+cabal-version:       >= 1.8
 tested-with:         GHC==8.0.1
 
 source-repository head


### PR DESCRIPTION
Fixes the following warning:

```
Warning: brainfuck.cabal:29:34: version operators used. To use version
operators the package needs to specify at least 'cabal-version: >= 1.8'.
```