### PR TITLE
Support mtl 2.3

### DIFF
--- a/Language/Brainfuck.hs
+++ b/Language/Brainfuck.hs
@@ -29,6 +29,7 @@ import Data.Word         ( Word8 )
 import Data.Char         ( ord, chr )
 import Data.List         ( groupBy )
 import Data.Maybe        ( catMaybes )
+import Control.Monad
 import Control.Monad.State
 
 {- | The complete BF language:


### PR DESCRIPTION
Control.Monad.State no longer reëxports Control.Monad

This change is enough to support building with GHC 9.6.